### PR TITLE
Making sure the pycache folder is excluded

### DIFF
--- a/pynsive/common.py
+++ b/pynsive/common.py
@@ -6,6 +6,7 @@ MODULE_PATH_SEP = '.'
 MODULE_INIT_FILE = '__init__.py'
 NAME_ATTRIBUTE = '__name__'
 PATH_ATTRUBITE = '__path__'
+PYCACHE_FOLDER = '__pycache__'
 
 
 def import_module(module_name):

--- a/pynsive/reflection.py
+++ b/pynsive/reflection.py
@@ -33,6 +33,9 @@ def _scan_for_modules(directory, recursive=False, prefix=None):
             # Skip the init file
             if entry == MODULE_INIT_FILE:
                 continue
+            # Skip the pycache folder
+            if entry == PYCACHE_FOLDER:
+                continue
             if entry.endswith('.py'):
                 module = entry.rstrip('.py')
                 if prefix:


### PR DESCRIPTION
For Python 3 compatibility we have to make sure we don't attempt to
import the **pycache** folder.

I noticed this issue as a result of doing some testing of Specter between Python 2.7 and Python 3.3. 
