### PR TITLE
Fixing module loading process for coverage integration

### DIFF
--- a/pynsive/plugin/loader.py
+++ b/pynsive/plugin/loader.py
@@ -39,14 +39,15 @@ class ModuleLoader(object):
         self.load_target = load_target
         self.is_pkg = is_pkg
 
-    def _read_code(self):
-        """
-        Simple abstraction to make reading a module file easy.
-        """
-        fin = open(self.load_target, 'r')
-        code = fin.read()
-        fin.close()
-        return code
+    def load_module_py_path(self, module_name, path):
+        file_ext = os.path.splitext(path)[1]
+        module = None
+        if file_ext.lower() == '.py':
+            module = imp.load_source(module_name, path)
+        elif file_ext.lower() == '.pyc':
+            module = imp.load_compiled(module_name, path)
+
+        return module
 
     def load_module(self, module_name):
         """
@@ -63,11 +64,7 @@ class ModuleLoader(object):
         if module_name in sys.modules:
             return sys.modules[module_name]
 
-        code = self._read_code()
-        module = imp.new_module(module_name)
-        module.__file__ = self.load_target
-        module.__loader__ = self
-
+        module = self.load_module_py_path(module_name, self.load_target)
         if self.is_pkg:
             module.__path__ = [self.module_path]
             module.__package__ = module_name
@@ -75,7 +72,6 @@ class ModuleLoader(object):
             module.__package__ = module_name.rpartition('.')[0]
 
         sys.modules[module_name] = module
-        exec(code, module.__dict__)
         return module
 
 

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -5,9 +5,7 @@ import unittest
 import pynsive
 
 
-INIT_PY = """
-from .test_classes import *
-"""
+INIT_PY = ""
 
 TEST_CLASSES_PY = """
 SUCCESS = True
@@ -100,7 +98,7 @@ class WhenLoading(unittest.TestCase):
         self.assertTrue(test_module.SUCCESS)
 
     def test_listing_classes(self):
-        classes = pynsive.list_classes('pynsive_test')
+        classes = pynsive.list_classes('pynsive_test.test_classes')
         self.assertEqual(len(classes), 2)
 
     def test_listing_classes_with_filter(self):
@@ -112,7 +110,8 @@ class WhenLoading(unittest.TestCase):
                 test_type, test_module.PynsiveTestingClass)
             return not same and is_subclass
 
-        classes = pynsive.list_classes('pynsive_test', subclasses_only)
+        classes = pynsive.list_classes('pynsive_test.test_classes',
+                                       subclasses_only)
         self.assertEqual(len(classes), 1)
 
     def test_importing_missing_module(self):
@@ -136,7 +135,7 @@ class WhenLoading(unittest.TestCase):
         self.assertTrue('pynsive_test.embedded.test' in found_modules)
 
     def test_discovering_classes(self):
-        classes = pynsive.list_classes('pynsive_test')
+        classes = pynsive.list_classes('pynsive_test.test_classes')
         self.assertEqual(2, len(classes))
 
     def test_recursively_discovering_classes(self):


### PR DESCRIPTION
The previous method of loading a module was causing coverage not to see
executed lines within loaded modules.

Fixes #11
